### PR TITLE
Use getControllerClass() instead of getController() as it is complete…

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -282,8 +282,8 @@ class Breadcrumbs extends NovaBreadcrumbs {
     }
 
     protected function pageType(NovaRequest $request) {
-        $controller = $request->route()->getController();
-        switch ($controller::class) {
+        $controller = $request->route()->getControllerClass();
+        switch ($controller) {
             case Pages\ResourceDetailController::class:
                 return "detail";
             case Pages\ResourceIndexController::class:

--- a/src/Http/Middleware/InterceptBreadcrumbs.php
+++ b/src/Http/Middleware/InterceptBreadcrumbs.php
@@ -26,7 +26,7 @@ class InterceptBreadcrumbs {
             return $next($request);
         }
 
-        $routeController = $request->route()->getController();
+        $routeController = $request->route()->getControllerClass();
 
         if ( $this->isPageController($routeController) && Nova::breadcrumbsEnabled()) {
             $request = NovaRequest::createFrom($request);
@@ -58,7 +58,7 @@ class InterceptBreadcrumbs {
         return $breadcrumbs;
     }
 
-    protected function isPageController($controller) {
-        return ((new \ReflectionClass($controller))?->getNamespaceName() ?? false) === "Laravel\Nova\Http\Controllers\Pages";
+    protected function isPageController(?string $controllerClass) {
+        return str_starts_with($controllerClass, "Laravel\Nova\Http\Controllers\Pages");
     }
 }


### PR DESCRIPTION
…ly unsafe to use if the route uses a closure